### PR TITLE
Add geolocation error handling with user-friendly messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,21 +224,32 @@
             }
         }
 
-        function show_error() {
-            $("#live-geolocation").html('Unable to determine your current weather.');
+        function show_error(error) {
+            var message;
+            switch(error && error.code) {
+                case 1:
+                    message = 'Location access denied. Please allow location access and refresh the page.';
+                    break;
+                case 2:
+                    message = 'Unable to determine your location. Please try again.';
+                    break;
+                case 3:
+                    message = 'Location request timed out. Please try again.';
+                    break;
+                default:
+                    message = 'Unable to determine your current weather.';
+            }
+            $("#answer_wrap").hide();
+            $("#live-geolocation").html(message);
         }
 
         function getLocation() {
             if (navigator.geolocation) {
-                navigator.geolocation.getCurrentPosition(get_WeatherJSON);
+                navigator.geolocation.getCurrentPosition(get_WeatherJSON, show_error);
             } else {
-                x.innerHTML = "Geolocation is not supported by this browser.";
+                $("#answer_wrap").hide();
+                $("#live-geolocation").html("Geolocation is not supported by this browser.");
             }
-        }
-
-        function showPosition(position) {
-            x.innerHTML = "Latitude: " + position.coords.latitude + "<br>Longitude: " + position.coords.longitude;
-            get_WeatherJSON(position);
         }
         getLocation();
     });


### PR DESCRIPTION
Previously, getCurrentPosition was called without an error callback, so denied/failed location requests left the page stuck on the loading spinner with no feedback. Also removes the dead showPosition function that referenced an undefined variable x.

Note: replace YOUR_OPENWEATHER_API_KEY in index.html with your actual key.

https://claude.ai/code/session_01L3zcjJox9NpxDSPYBVxCxb